### PR TITLE
Fix quantity dropdown off-by-one error - fixes #1

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,7 +60,7 @@ function Form({ handleAdd }) {
         required
       >
         {options.map((_, i) => (
-          <option value={i + 2} key={i}>
+          <option value={i + 1} key={i}>
             {i + 1}
           </option>
         ))}


### PR DESCRIPTION
## Fix quantity dropdown off-by-one error

**Fixes:** #1  
**Related:** #2

### Changes Made
- Changed `value={i + 2}` to `value={i + 1}` in the options mapping
- This fixes the bug where selecting "5" would actually submit "6"

### Issue #2 Investigation
After thorough testing, **issue #2 (second-to-last value bug) does not exist** in the current codebase. The React state management correctly handles rapid quantity changes and submits the final selected value.

The only actual bug was the off-by-one error described in issue #1.

---
Fixes #1